### PR TITLE
Add documentation and tests for Data extension

### DIFF
--- a/Sources/LRUActorCache/MemoryCache.swift
+++ b/Sources/LRUActorCache/MemoryCache.swift
@@ -15,6 +15,27 @@ public protocol CachedValue: Sendable {
     static func fromData(data: Data) throws -> Self
 }
 
+/// Conformance of `Data` to `CachedValue` protocol.
+///
+/// This extension allows `Data` objects to be stored directly in the cache
+/// without requiring a wrapper type. Since `Data` is already serialized,
+/// the implementation simply returns itself for both serialization and
+/// deserialization operations.
+extension Data: CachedValue {
+    /// Returns self as the serialized data representation.
+    ///
+    /// Since `Data` is already in a serialized format, no conversion is needed.
+    public var data: Data { self }
+    
+    /// Creates a `Data` instance from serialized data.
+    ///
+    /// Since the input is already `Data`, this method simply returns it unchanged.
+    ///
+    /// - Parameter data: The serialized data.
+    /// - Returns: The same `Data` instance.
+    public static func fromData(data: Data) throws -> Data { data }
+}
+
 // MARK: - Container Class
 
 // MARK: - MemoryCache Actor

--- a/Tests/LRUActorCacheTests/LRUActorCacheTests.swift
+++ b/Tests/LRUActorCacheTests/LRUActorCacheTests.swift
@@ -241,3 +241,101 @@ struct CacheTest {
         #expect(finalValue?.someValue.starts(with: "update") == true, "Stored value should be one of the updates")
     }
 }
+
+// MARK: - Data Extension Tests
+
+@Suite("DataCachedValueTests", .serialized)
+struct DataCachedValueTests {
+    @Test("Data conforms to CachedValue")
+    func dataConformsToCachedValue() {
+        // Verify Data.data returns self
+        let testData = "Hello, World!".data(using: .utf8)!
+        #expect(testData.data == testData, "Data.data should return self")
+        
+        // Verify Data.fromData returns input unchanged
+        let result = try? Data.fromData(data: testData)
+        #expect(result == testData, "Data.fromData should return the input unchanged")
+    }
+    
+    @Test("Store and retrieve Data in MemoryCache")
+    func storeAndRetrieveDataInMemoryCache() async throws {
+        let cache = MemoryCache<String, Data>()
+        let key = "dataKey"
+        let testData = "Test data content".data(using: .utf8)!
+        
+        // Store Data
+        await cache.set(testData, for: key)
+        
+        // Retrieve Data
+        let retrievedData = await cache.value(for: key)
+        #expect(retrievedData == testData, "Retrieved Data should match stored Data")
+        
+        // Verify contains
+        #expect(await cache.contains(key), "Cache should contain the Data key")
+    }
+    
+    @Test("Store and retrieve Data in DiskCache")
+    func storeAndRetrieveDataInDiskCache() {
+        let cache = DiskCache<String, Data>()
+        let key = "diskDataKey"
+        let testData = "Persistent data content".data(using: .utf8)!
+        
+        // Store Data
+        cache.setValue(testData, at: key)
+        
+        // Retrieve Data
+        let retrievedData = cache.getData(for: key)
+        #expect(retrievedData == testData, "Retrieved Data from disk should match stored Data")
+    }
+    
+    @Test("Data persistence within same cache instance")
+    func dataPersistenceWithinSameCacheInstance() async throws {
+        let cache = MemoryCache<String, Data>()
+        let key = "persistentDataKey"
+        let testData = "Persistent data".data(using: .utf8)!
+        
+        // Store data
+        await cache.set(testData, for: key)
+        
+        // Retrieve from same instance (should be in memory)
+        let fromMemory = await cache.value(for: key)
+        #expect(fromMemory == testData, "Data should be retrievable from memory")
+        
+        // Verify it's in the cache
+        #expect(await cache.contains(key), "Cache should contain the key")
+        
+        // Note: Each cache instance has its own disk directory, so data doesn't persist across instances
+    }
+    
+    @Test("Large Data handling")
+    func largeDataHandling() async throws {
+        let cache = MemoryCache<String, Data>()
+        let key = "largeDataKey"
+        
+        // Create 1MB of data
+        let largeData = Data(repeating: 0xFF, count: 1024 * 1024)
+        
+        // Store large Data
+        await cache.set(largeData, for: key)
+        
+        // Retrieve and verify
+        let retrievedData = await cache.value(for: key)
+        #expect(retrievedData == largeData, "Large Data should be stored and retrieved correctly")
+        #expect(retrievedData?.count == 1024 * 1024, "Retrieved Data size should match")
+    }
+    
+    @Test("Empty Data handling")
+    func emptyDataHandling() async throws {
+        let cache = MemoryCache<String, Data>()
+        let key = "emptyDataKey"
+        let emptyData = Data()
+        
+        // Store empty Data
+        await cache.set(emptyData, for: key)
+        
+        // Retrieve and verify
+        let retrievedData = await cache.value(for: key)
+        #expect(retrievedData == emptyData, "Empty Data should be stored and retrieved")
+        #expect(retrievedData?.isEmpty == true, "Retrieved Data should be empty")
+    }
+}


### PR DESCRIPTION
- Add comprehensive DocC documentation for Data conformance to CachedValue
- Explain that Data returns itself for serialization/deserialization
- Add unit tests covering Data caching functionality
- Test basic conformance, MemoryCache/DiskCache integration
- Test edge cases including large data and empty data
- All tests passing

The Data extension allows raw Data objects to be cached directly without requiring a wrapper type.

