### PR TITLE
Update platform requirements to v26 beta

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "LRUActorCache",
     platforms: [
-        .iOS(.v18),
-        .macOS(.v15),
+        .iOS(.v26),
+        .macOS(.v26),
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.


### PR DESCRIPTION
## Summary
- Updated iOS platform requirement from v18 to v26 beta
- Updated macOS platform requirement from v15 to v26 beta

## Test plan
- [x] Run `swift test` - all tests pass
- [x] Build successfully with Swift 6.2

🤖 Generated with [Claude Code](https://claude.ai/code)